### PR TITLE
Load User model from AUTH_USER_MODEL

### DIFF
--- a/djangocms_4_migration/migrations/0004_migrate_permissions.py
+++ b/djangocms_4_migration/migrations/0004_migrate_permissions.py
@@ -1,9 +1,13 @@
+from django.conf import settings
 from django.db import migrations
 
 
 def forwards(apps, schema_editor):
     ContentType = apps.get_model('contenttypes', 'ContentType')
-    User = apps.get_model('auth', 'User')
+
+    user_app_label, user_model_name = settings.AUTH_USER_MODEL.split('.')
+    User = apps.get_model(user_app_label, user_model_name)
+
     Group = apps.get_model('auth', 'Group')
     Permission = apps.get_model('auth', 'Permission')
 


### PR DESCRIPTION
Running the migrations with a custom users results in an AttributeError:

```
AttributeError: Manager isn't available; 'auth.User' has been swapped for 'users.User'
```

Taking AUTH_USER_MODEL into account solves this.